### PR TITLE
Sweetmantech/myc 2250 docs apitimeline hidden param and any missing params

### DIFF
--- a/docs/pages/timeline/index.mdx
+++ b/docs/pages/timeline/index.mdx
@@ -129,7 +129,8 @@ The API returns JSON responses. Here's an example success response:
       "uri": "ar://1wMmKuaz-VdxmruOQJuYS-3nfU3zlNKmPNpc79Ou-qM",
       "admin": "0x29b6674c1562e31EdFd9709D9576e8E5F1e68d01",
       "createdAt": "2025-06-07T20:41:35+00:00",
-      "username": "artistname"
+      "username": "artist name",
+      "hidden": false
     },
     {
       "address": "0x317e6E49970b95DD1bF2E7877110f3278CB8f1EA",
@@ -139,7 +140,8 @@ The API returns JSON responses. Here's an example success response:
       "uri": "ar://T5bcXlR7waq_aexj0Sp7SXR5uvwg3qAlMuai9oh6w-U",
       "admin": "0x4b4324bcC6dB9380ABBbbD20B24A16C11FB5B38A",
       "createdAt": "2025-06-07T17:13:07+00:00",
-      "username": ""
+      "username": "artist name",
+      "hidden": false
     }
   ],
   "pagination": {
@@ -155,23 +157,24 @@ The API returns JSON responses. Here's an example success response:
 
 ### Response Object
 
-| Property               | Type   | Description                                  |
-| ---------------------- | ------ | -------------------------------------------- |
-| status                 | string | Status of the request ("success" or "error") |
-| moments                | array  | List of moments in the timeline              |
-| moments[].address      | string | Moment contract address                      |
-| moments[].tokenId      | string | Moment ID                                    |
-| moments[].chainId      | number | Chain ID                                     |
-| moments[].id           | string | UUID of the moment                           |
-| moments[].uri          | string | Metadata URI                                 |
-| moments[].admin        | string | Admin address                                |
-| moments[].createdAt    | string | ISO timestamp when the moment was created    |
-| moments[].username     | string | Username of the admin/artist, if available   |
-| pagination             | object | Pagination metadata for the response         |
-| pagination.total_count | number | Total number of moments available            |
-| pagination.page        | number | Current page number                          |
-| pagination.limit       | number | Number of moments per page                   |
-| pagination.total_pages | number | Total number of pages available              |
+| Property               | Type    | Description                                  |
+| ---------------------- | ------- | -------------------------------------------- |
+| status                 | string  | Status of the request ("success" or "error") |
+| moments                | array   | List of moments in the timeline              |
+| moments[].address      | string  | Moment contract address                      |
+| moments[].tokenId      | string  | Moment ID                                    |
+| moments[].chainId      | number  | Chain ID                                     |
+| moments[].id           | string  | UUID of the moment                           |
+| moments[].uri          | string  | Metadata URI                                 |
+| moments[].admin        | string  | Admin address                                |
+| moments[].createdAt    | string  | ISO timestamp when the moment was created    |
+| moments[].username     | string  | Username of the admin/artist, if available   |
+| moments[].hidden       | boolean | Whether the moment is hidden (admin only)    |
+| pagination             | object  | Pagination metadata for the response         |
+| pagination.total_count | number  | Total number of moments available            |
+| pagination.page        | number  | Current page number                          |
+| pagination.limit       | number  | Number of moments per page                   |
+| pagination.total_pages | number  | Total number of pages available              |
 
 ## Error Response
 

--- a/docs/pages/timeline/index.mdx
+++ b/docs/pages/timeline/index.mdx
@@ -23,25 +23,28 @@ GET https://inprocess.fun/api/timeline
 | latest  | boolean | No       | true    | Sort by most recent first                                                  |
 | artist  | string  | No       | —       | Filter by admin address (only moments administered by this artist address) |
 | chainId | number  | No       | 8453    | Filter by chain ID (default: Base chain, 8453)                             |
+| hidden  | boolean | No       | false   | If true, includes moments marked as hidden by the admin (default: false)   |
 
-You can filter the timeline to only show moments administered by a specific artist by providing the `artist` address as a query parameter. You can also filter by chain using the `chainId` parameter (default: 8453 for Base).
+You can filter the timeline to only show moments administered by a specific artist by providing the `artist` address as a query parameter. You can also filter by chain using the `chainId` parameter (default: 8453 for Base). To include moments that have been marked as hidden by the admin, set the `hidden` parameter to `true` (defaults to `false`).
 
 ## Request Examples
 
 :::code-group
 
 ```bash [cURL]
-curl -X GET "https://inprocess.fun/api/timeline?chainId=8453&limit=2&page=1&latest=true"
+curl -X GET "https://inprocess.fun/api/timeline?artist=0x29b6674c1562e31EdFd9709D9576e8E5F1e68d01&chainId=8453&limit=2&page=1&latest=true&hidden=true"
 ```
 
 ```python [Python]
 import requests
 
-def get_timeline(page: int = 1, limit: int = 100, latest: bool = True, artist: str = None, chainId: int = 8453):
+def get_timeline(page: int = 1, limit: int = 100, latest: bool = True, artist: str = None, chainId: int = 8453, hidden: bool = False):
     url = "https://inprocess.fun/api/timeline"
     params = {"page": page, "limit": limit, "latest": latest, "chainId": chainId}
     if artist:
         params["artist"] = artist
+    if hidden:
+        params["hidden"] = str(hidden).lower()
     response = requests.get(url, params=params)
     response.raise_for_status()
     return response.json()
@@ -53,7 +56,8 @@ async function getTimeline(
   limit = 100,
   latest = true,
   artist,
-  chainId = 8453
+  chainId = 8453,
+  hidden = false
 ) {
   const params = new URLSearchParams({
     page: page.toString(),
@@ -62,6 +66,7 @@ async function getTimeline(
     chainId: chainId.toString(),
   });
   if (artist) params.set("artist", artist);
+  if (hidden) params.set("hidden", hidden.toString());
   const response = await fetch(`https://inprocess.fun/api/timeline?${params}`);
   if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
   return await response.json();
@@ -96,7 +101,8 @@ async function getTimeline(
   limit: number = 100,
   latest: boolean = true,
   artist?: string,
-  chainId: number = 8453
+  chainId: number = 8453,
+  hidden: boolean = false
 ): Promise<TimelineResponse> {
   const params = new URLSearchParams({
     page: page.toString(),
@@ -105,6 +111,7 @@ async function getTimeline(
     chainId: chainId.toString(),
   });
   if (artist) params.set("artist", artist);
+  if (hidden) params.set("hidden", hidden.toString());
   const response = await fetch(`https://inprocess.fun/api/timeline?${params}`);
   if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
   return await response.json();

--- a/docs/pages/timeline/index.mdx
+++ b/docs/pages/timeline/index.mdx
@@ -22,38 +22,48 @@ GET https://inprocess.fun/api/timeline
 | page   | number  | No       | The page number to retrieve (default: 1)                                   |
 | latest | boolean | No       | Sort by most recent first (default: true)                                  |
 | artist | string  | No       | Filter by admin address (only moments administered by this artist address) |
+| hidden | boolean | No       | If true, includes moments marked as hidden by the admin (default: false)   |
 
-You can filter the timeline to only show moments administered by a specific artist by providing the `artist` address as a query parameter.
+You can filter the timeline to only show moments administered by a specific artist by providing the `artist` address as a query parameter. To include moments that have been marked as hidden by the admin, set the `hidden` parameter to `true` (defaults to `false`).
 
 ## Request Examples
 
 :::code-group
 
 ```bash [cURL]
-curl -X GET "https://inprocess.fun/api/timeline?artist=0x29b6674c1562e31EdFd9709D9576e8E5F1e68d01&limit=2&page=1&latest=true"
+curl -X GET "https://inprocess.fun/api/timeline?artist=0x29b6674c1562e31EdFd9709D9576e8E5F1e68d01&hidden=true&limit=2&page=1&latest=true"
 ```
 
 ```python [Python]
 import requests
 
-def get_timeline(page: int = 1, limit: int = 20, latest: bool = True, artist: str = None):
+def get_timeline(page: int = 1, limit: int = 20, latest: bool = True, artist: str = None, hidden: bool = False):
     url = "https://inprocess.fun/api/timeline"
     params = {"page": page, "limit": limit, "latest": latest}
     if artist:
         params["artist"] = artist
+    if hidden:
+        params["hidden"] = str(hidden).lower()
     response = requests.get(url, params=params)
     response.raise_for_status()
     return response.json()
 ```
 
 ```javascript [JavaScript]
-async function getTimeline(page = 1, limit = 20, latest = true, artist) {
+async function getTimeline(
+  page = 1,
+  limit = 20,
+  latest = true,
+  artist,
+  hidden = false
+) {
   const params = new URLSearchParams({
     page: page.toString(),
     limit: limit.toString(),
     latest: latest.toString(),
   });
   if (artist) params.set("artist", artist);
+  if (hidden) params.set("hidden", hidden.toString());
   const response = await fetch(`https://inprocess.fun/api/timeline?${params}`);
   if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
   return await response.json();
@@ -86,7 +96,8 @@ async function getTimeline(
   page: number = 1,
   limit: number = 20,
   latest: boolean = true,
-  artist?: string
+  artist?: string,
+  hidden: boolean = false
 ): Promise<TimelineResponse> {
   const params = new URLSearchParams({
     page: page.toString(),
@@ -94,6 +105,7 @@ async function getTimeline(
     latest: latest.toString(),
   });
   if (artist) params.set("artist", artist);
+  if (hidden) params.set("hidden", hidden.toString());
   const response = await fetch(`https://inprocess.fun/api/timeline?${params}`);
   if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
   return await response.json();

--- a/docs/pages/timeline/index.mdx
+++ b/docs/pages/timeline/index.mdx
@@ -16,34 +16,32 @@ GET https://inprocess.fun/api/timeline
 
 ## Parameters
 
-| Name   | Type    | Required | Description                                                                |
-| ------ | ------- | -------- | -------------------------------------------------------------------------- |
-| limit  | number  | No       | Number of records per page (default: 20, max: 100)                         |
-| page   | number  | No       | The page number to retrieve (default: 1)                                   |
-| latest | boolean | No       | Sort by most recent first (default: true)                                  |
-| artist | string  | No       | Filter by admin address (only moments administered by this artist address) |
-| hidden | boolean | No       | If true, includes moments marked as hidden by the admin (default: false)   |
+| Name    | Type    | Required | Default | Description                                                                |
+| ------- | ------- | -------- | ------- | -------------------------------------------------------------------------- |
+| limit   | number  | No       | 100     | Number of records per page (max: 100)                                      |
+| page    | number  | No       | 1       | The page number to retrieve                                                |
+| latest  | boolean | No       | true    | Sort by most recent first                                                  |
+| artist  | string  | No       | —       | Filter by admin address (only moments administered by this artist address) |
+| chainId | number  | No       | 8453    | Filter by chain ID (default: Base chain, 8453)                             |
 
-You can filter the timeline to only show moments administered by a specific artist by providing the `artist` address as a query parameter. To include moments that have been marked as hidden by the admin, set the `hidden` parameter to `true` (defaults to `false`).
+You can filter the timeline to only show moments administered by a specific artist by providing the `artist` address as a query parameter. You can also filter by chain using the `chainId` parameter (default: 8453 for Base).
 
 ## Request Examples
 
 :::code-group
 
 ```bash [cURL]
-curl -X GET "https://inprocess.fun/api/timeline?artist=0x29b6674c1562e31EdFd9709D9576e8E5F1e68d01&hidden=true&limit=2&page=1&latest=true"
+curl -X GET "https://inprocess.fun/api/timeline?chainId=8453&limit=2&page=1&latest=true"
 ```
 
 ```python [Python]
 import requests
 
-def get_timeline(page: int = 1, limit: int = 20, latest: bool = True, artist: str = None, hidden: bool = False):
+def get_timeline(page: int = 1, limit: int = 100, latest: bool = True, artist: str = None, chainId: int = 8453):
     url = "https://inprocess.fun/api/timeline"
-    params = {"page": page, "limit": limit, "latest": latest}
+    params = {"page": page, "limit": limit, "latest": latest, "chainId": chainId}
     if artist:
         params["artist"] = artist
-    if hidden:
-        params["hidden"] = str(hidden).lower()
     response = requests.get(url, params=params)
     response.raise_for_status()
     return response.json()
@@ -52,18 +50,18 @@ def get_timeline(page: int = 1, limit: int = 20, latest: bool = True, artist: st
 ```javascript [JavaScript]
 async function getTimeline(
   page = 1,
-  limit = 20,
+  limit = 100,
   latest = true,
   artist,
-  hidden = false
+  chainId = 8453
 ) {
   const params = new URLSearchParams({
     page: page.toString(),
     limit: limit.toString(),
     latest: latest.toString(),
+    chainId: chainId.toString(),
   });
   if (artist) params.set("artist", artist);
-  if (hidden) params.set("hidden", hidden.toString());
   const response = await fetch(`https://inprocess.fun/api/timeline?${params}`);
   if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
   return await response.json();
@@ -79,6 +77,7 @@ export interface Moment {
   uri: string;
   admin: string; // Address
   createdAt: string; // timestampz
+  username: string; // Username of the admin/artist, if available
 }
 
 export interface TimelineResponse {
@@ -94,18 +93,18 @@ export interface TimelineResponse {
 
 async function getTimeline(
   page: number = 1,
-  limit: number = 20,
+  limit: number = 100,
   latest: boolean = true,
   artist?: string,
-  hidden: boolean = false
+  chainId: number = 8453
 ): Promise<TimelineResponse> {
   const params = new URLSearchParams({
     page: page.toString(),
     limit: limit.toString(),
     latest: latest.toString(),
+    chainId: chainId.toString(),
   });
   if (artist) params.set("artist", artist);
-  if (hidden) params.set("hidden", hidden.toString());
   const response = await fetch(`https://inprocess.fun/api/timeline?${params}`);
   if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
   return await response.json();
@@ -129,7 +128,8 @@ The API returns JSON responses. Here's an example success response:
       "id": "bceddfb3-28f2-49f3-8669-73a813a06b90",
       "uri": "ar://1wMmKuaz-VdxmruOQJuYS-3nfU3zlNKmPNpc79Ou-qM",
       "admin": "0x29b6674c1562e31EdFd9709D9576e8E5F1e68d01",
-      "createdAt": "2025-06-07T20:41:35+00:00"
+      "createdAt": "2025-06-07T20:41:35+00:00",
+      "username": "artistname"
     },
     {
       "address": "0x317e6E49970b95DD1bF2E7877110f3278CB8f1EA",
@@ -138,7 +138,8 @@ The API returns JSON responses. Here's an example success response:
       "id": "5fc69bea-1a8a-47f0-8652-8bf041c16a06",
       "uri": "ar://T5bcXlR7waq_aexj0Sp7SXR5uvwg3qAlMuai9oh6w-U",
       "admin": "0x4b4324bcC6dB9380ABBbbD20B24A16C11FB5B38A",
-      "createdAt": "2025-06-07T17:13:07+00:00"
+      "createdAt": "2025-06-07T17:13:07+00:00",
+      "username": ""
     }
   ],
   "pagination": {
@@ -165,8 +166,20 @@ The API returns JSON responses. Here's an example success response:
 | moments[].uri          | string | Metadata URI                                 |
 | moments[].admin        | string | Admin address                                |
 | moments[].createdAt    | string | ISO timestamp when the moment was created    |
+| moments[].username     | string | Username of the admin/artist, if available   |
 | pagination             | object | Pagination metadata for the response         |
 | pagination.total_count | number | Total number of moments available            |
 | pagination.page        | number | Current page number                          |
 | pagination.limit       | number | Number of moments per page                   |
 | pagination.total_pages | number | Total number of pages available              |
+
+## Error Response
+
+If an error occurs, the API returns:
+
+```json
+{
+  "status": "error",
+  "message": "...error message..."
+}
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated timeline API documentation to include new optional `chainId` and `hidden` query parameters with default values.
  - Expanded parameters and response tables to include `username` and `hidden` fields in responses.
  - Revised example requests and responses to reflect these additions.
  - Added an error response section detailing the error structure.
  - Increased default pagination limits in examples from 20 to 100.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->